### PR TITLE
DOCS-4320 Update docs and link to acs-deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,213 +1,44 @@
 
 # Alfresco Content Services Community Deployment
 
+This project contains the code for starting the entire Alfresco Content Services (Community Edition) product with **Docker** or **Kubernetes**.
+
+For the Enterprise project, go to [acs-deployment](https://github.com/Alfresco/acs-deployment). The only difference between these projects are:
+* In the Community chart, clustering is not supported, so only a single `alfresco-content-repository` node is started by default.
+
+## Contents of the deployment
+
+Alfresco Content Services Community deployed via `docker-compose` or Kubernetes contains the following:
+1. Alfresco Repository for Community, with:  
+1.1. Alfresco Share Services AMP  
+1.2. Alfresco AOS AMP  
+1.3. Alfresco vti-bin war - helps with AOS integration  
+1.4. Alfresco Google Docs Repo AMP  
+2. Alfresco Share, with:  
+2.1 Alfresco Google Docks Share AMP  
+3. A Postgres DB  
+4. Alfresco Search Services (Solr6)  
+
+## Deployment options
+
+To deploy Alfresco Content Services Community, follow the steps in the [acs-deployment](https://github.com/Alfresco/acs-deployment) project using the links provided.
+
+**Note:** You'll need to adapt some steps and commands for the Community release. Replace any occurrences of `alfresco-content-repository` with `alfresco-content-repository-community` to ensure you're using the Community release. Example commands may need to be changed when cloning the Community project, changing directory, or deploying the Community Helm chart:
+* [Deploying with Helm charts on AWS](https://github.com/Alfresco/acs-deployment/docs/helm-deployment-aws_cloud.md)
+* [Deploying with Helm charts using Minikube](https://github.com/Alfresco/acs-deployment/docs/helm-deployment-minikube.md)
+* [Deploying using Docker Compose](https://github.com/Alfresco/acs-deployment/docs/docker-compose-deployment.md)
+
+Use the steps in this project to customize your deployment:
+* [Customizing your deployment](docs/customising-deployment.md)
+
+
+## Other information
+
+* See alternative commands and start up [tutorial with AWS support](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/running-a-cluster.md)
+* [Tips and tricks](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/tips-and-tricks.md) for working with Kubernetes and Alfresco Content Services.
+
+**Note:** You'll need to adapt some steps and commands for the Community release.
+
+
 ### Contributing guide
 Please use [this guide](CONTRIBUTING.md) to make a contribution to the project.
-
-This project contains the code for starting the entire Alfresco Content Services product Community edition with **docker or kubernetes**.
-
-## Docker-compose & Kubernetes
-Start Alfresco Content Services Community using docker-compose or Kubernetes, containing:
-1. Alfresco Repository for community, with:  
-1.1. Alfresco Share Services amp  
-1.2. Alfresco AOS amp  
-1.3. Alfresco vti-bin war - that helps with AOS integration  
-1.4. Alfresco Google Docs Repo amp  
-2. Alfresco Share, with:  
-2.1 Alfresco Google Docks Share amp  
-3. A Postgres DB  
-4. Alfresco Solr6  
-
-### Docker Compose Instructions:
-#### Prerequisite:
-* Docker installed locally
-
-#### Steps
-1. Go to **docker-compose** folder
-2. Run ```docker-compose up```
-3. Check that everything starts up with the browser: http://localhost:8082/alfresco and http://localhost:8080/share and http://localhost:8083/solr/
-
-#### Notes:
-* Make sure the local machine has the ports (5432, 8080, 8082, 8083) set up in the docker-compose.yml file free.
-
-### How to get started with Kubernetes and Alfresco Content Services Community.
-
-#### Assumptions
-
-We will be using minikube to demonstrate how you can deploy the Alfresco Content Services Community helm charts. We will assume that you are familiar with the Kubernetes technology - at least basic knowledge, and there is also the assumption that you have a working minikube setup that you can use. Running some kind of [hello-world application](https://github.com/kubernetes/helm/blob/master/docs/chart_template_guide/getting_started.md) in your minikube cluster usually proves that it is set up correctly.
-
-If you are not familiar with [Kubernetes](https://kubernetes.io/) (also written as k8s), there are a lot of tutorials and guides online to get you started. Here are some starting points:
-* https://github.com/kubernetes/kubernetes -> this has a section [To start using kubernetes](https://github.com/kubernetes/kubernetes#to-start-using-kubernetes) with some hands on tutorials.
-* https://github.com/kubernetes/minikube -> this explains what minikube and kubectl is.
-* https://helm.sh/ -> information about helm package manager.
-
-For these examples, we assume that we will use the default namespace. The professional thing to do is to use proper namespaces to separate your deployments so, do use namespace if you want. Proper examples in the **tutorial with AWS support** linked in the _Other information_ section at the end.
-
-#### Step 1: Make sure your minikube is setup, started and running fine
-
-Setting up and starting up minikube may be a little bit different depending on the environment you are working with. Setting up, usually, involves just downloading the **minikube**, **kubectl** and **helm** binaries and adding them to the PATH system variable.
-Please use the versions specified here https://github.com/Alfresco/alfresco-infrastructure-deployment .
-
-**Resource requirement for testing**: allocate at least 6GB or RAM, 4 CPU cores and 20GB disk space to your minikube VM.
-
-##### minikube
-
-Example of start up command on windows (you need to have the "My_Virtual_Switch" set up before this first command - see [blog](https://blogs.msdn.microsoft.com/wasimbloch/2017/01/23/setting-up-kubernetes-on-windows10-laptop-with-minikube/)):
-```bash
-minikube start --vm-driver="hyperv" --cpus=4 --memory=6000 --hyperv-virtual-switch="My_Virtual_Switch" --v=7 --alsologtostderr
-```
-This will download a linux iso and install it in your Hyper V Manager - you should see a **minikube** VM, after it is installed. It also installs all the needed software in that VM, to simulate a kubernetes cluster.  
-**Note:** you may need to add ```--extra-config=kubelet.ImagePullProgressDeadline=30m0s``` parameter to your start command, as the docker images are rather big.  
-
-##### helm
-Run this command to initialize helm:
-```bash
-helm init
-```
-Note: If you are using minikube 0.26.0+ (with RBAC) use the following:
-```bash
-kubectl create serviceaccount --namespace kube-system tiller
-kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-helm init --service-account tiller
-```
-
-##### commands to check the minikube kubernetes cluster is running:
-```bash
-minikube version
-minikube ip
-# the following command opens a web UI of the minikube cluster
-minikube dashboard
-
-helm version
-helm repo list
-
-kubectl version
-kubectl get pods
-kubectl get secrets
-```
-
-#### Step 2: Install the ingress service:
-```bash
-helm repo update
-helm install stable/nginx-ingress --version 0.14.0
-# Add '--set rbac.create=true' if the environment has RBAC enabled
-# After running this command look for the name of the ingress deployment.
-# It is usually an animal name preceded by an adjective like: "singed-chipmunk"
-
-# Next get the ip and port of the ingress controller
-minikube ip
-# It will print something like: 172.31.147.123
-
-# To get the port, replace "singed-chipmunk" with the name of
-# your nginx-ingress-controller deployment
-kubectl get service singed-chipmunk-nginx-ingress-controller -o jsonpath={.spec.ports[0].nodePort}
-# This will print a port like: 30917
-
-# Remember the ip from the prev command and port to get the
-# external address value: http://172.31.147.123:30917 that we will use later
-```
-
-#### Step 3 Add the alfresco incubator helm repository
-
-We need this to add the persistent volume claim defined in the infrastructure. Everything else in the infrastructure is disabled for the moment, but the idea is that in the future we could easily enable components based on the new features that we will enable/implement.
-
-### Add the incubator helm repo:
-```bash
-helm repo add alfresco-incubator http://kubernetes-charts.alfresco.com/incubator
-helm repo list
-```
-
-#### Step 4: Deploy Alfresco Content Services Community from the alfresco incubator helm repository
-
-When you install Alfresco Content Services Community from the alfresco helm repository, you don't need to download any code locally. All the charts will be picked up from the helm repository.
-
-##### Install ACS Community:
-
-**Note:** Use the correct external address for your deployment of ingress from the prev Step 2.
-
-```bash
-helm install alfresco-incubator/alfresco-content-services-community --set externalProtocol="http" --set externalHost="172.31.147.123" --set externalPort="30917"
-```
-
-#### Alternative Step 4: Deploy Alfresco Content Services Community from the source code
-
-If you want to modify the deployment, and test it, you probably want to use the deployment method from code.
-
-**Note:** You still need to do Step 3 to add the alfresco helm repo for this step to work.
-
-##### Take the code (and modify it if you want)
-
-From https://github.com/Alfresco/acs-community-deployment
-```bash
-git clone git@github.com:Alfresco/acs-community-deployment.git
-cd acs-community-deployment
-```
-##### Update the dependencies required
-
-The current directory is important. Pay attention!
-```bash
-cd helm/alfresco-content-services-community
-helm dependency update
-cd ..
-```
-##### Install ACS Community
-
-```bash
-# make sure you are in the /helm folder
-helm install alfresco-content-services-community --set externalProtocol="http" --set externalHost="172.31.147.123" --set externalPort="30917"
-```
-
-#### Step 5: Check that ACS Community is running
-
-After running the ```helm install alfresco-content-services-community``` command you should see something like:
-```
-.....
-  Content: http://172.31.147.123:30917/alfresco
-  Share: http://172.31.147.123:30917/share
-  Solr: http://172.31.147.123:30917/solr
-```
-And after enough time has passed for the minikube to download all the docker images needed and to start them up, you should be able to open your browser to those addresses and check that alfresco, share and solr work fine.  
-
-You can also use kubectl/helm commands to check the status and logs of the pods in the deployment.
-
-### Customising alfresco community deployment.
-Alfresco Content Services Community is composed out of the following images:
-1. alfresco-content-repository-community |  [tags](https://hub.docker.com/r/alfresco/alfresco-content-repository-community/tags/)
-5. alfresco-share | [tags](https://hub.docker.com/r/alfresco/alfresco-share/tags/)
-6. alfresco-search-services | [tags](https://hub.docker.com/r/alfresco/alfresco-search-services/tags/)
-7. postgres | [tags](https://hub.docker.com/r/library/postgres/tags/)
-
-For docker-compose usage, edit image tags in [docker-compose.yml](https://github.com/Alfresco/acs-community-deployment/blob/master/docker-compose/docker-compose.yml) file.  
-For helm charts usage, edit image tags in [values.yaml](https://github.com/Alfresco/acs-community-deployment/blob/master/helm/alfresco-content-services-community/values.yaml) file.  
-
-```
-project
-│
-└───docker-compose
-│   │
-│   └──docker-compose.yml
-│
-└───helm
-    │  
-    └───alfresco-content-services
-        │
-        └───values.yaml
-```
-
-#### Notes:  
-Not all combination of image tags may work, please use the recommended ones.
-
-#### Other information
-
-You can find the helm chart [here](https://github.com/Alfresco/acs-community-deployment/tree/master/helm/alfresco-content-services-community).
-
-The system should handle pod recreation without any problem - persistent storage is implemented.
-
-Alternative commands and start up [tutorial with AWS support](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/running-a-cluster.md) You will need to adapt some steps for the Community release.
-
-[Tips and tricks](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/tips-and-tricks.md) for working with kubernetes and ACS. Some steps and commands need to be adapted for the Community release.
-
-
-#### Notes:
-* You can also change those values when deploying the helm chart by running ```helm install alfresco-incubator/alfresco-content-services --set repository.image.tag="yourTag" --set share.image.tag="yourTag"```.
-* Hint: Run  ```eval $(minikube docker-env)``` to switch to your minikube docker environment on osx.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 
 # Alfresco Content Services Community Deployment
 
+
+### Contributing guide
+Please use [this guide](CONTRIBUTING.md) to make a contribution to the project.
+
 This project contains the code for starting the entire Alfresco Content Services (Community Edition) product with **Docker** or **Kubernetes**.
 
 For the Enterprise project, go to [acs-deployment](https://github.com/Alfresco/acs-deployment). The only difference between these projects are:
@@ -24,9 +28,9 @@ Alfresco Content Services Community deployed via `docker-compose` or Kubernetes 
 To deploy Alfresco Content Services Community, follow the steps in the [acs-deployment](https://github.com/Alfresco/acs-deployment) project using the links provided.
 
 **Note:** You'll need to adapt some steps and commands for the Community release. Replace any occurrences of `alfresco-content-repository` with `alfresco-content-repository-community` to ensure you're using the Community release. Example commands may need to be changed when cloning the Community project, changing directory, or deploying the Community Helm chart:
-* [Deploying with Helm charts on AWS](https://github.com/Alfresco/acs-deployment/docs/helm-deployment-aws_cloud.md)
-* [Deploying with Helm charts using Minikube](https://github.com/Alfresco/acs-deployment/docs/helm-deployment-minikube.md)
-* [Deploying using Docker Compose](https://github.com/Alfresco/acs-deployment/docs/docker-compose-deployment.md)
+* [Deploying with Helm charts on AWS](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm-deployment-aws_cloud.md)
+* [Deploying with Helm charts using Minikube](https://github.com/Alfresco/acs-deployment/blob/master/docs/helm-deployment-minikube.md)
+* [Deploying using Docker Compose](https://github.com/Alfresco/acs-deployment/blob/master/docs/docker-compose-deployment.md)
 
 Use the steps in this project to customize your deployment:
 * [Customizing your deployment](docs/customising-deployment.md)
@@ -38,7 +42,3 @@ Use the steps in this project to customize your deployment:
 * [Tips and tricks](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/tips-and-tricks.md) for working with Kubernetes and Alfresco Content Services.
 
 **Note:** You'll need to adapt some steps and commands for the Community release.
-
-
-### Contributing guide
-Please use [this guide](CONTRIBUTING.md) to make a contribution to the project.

--- a/README.md
+++ b/README.md
@@ -40,5 +40,3 @@ Use the steps in this project to customize your deployment:
 
 * See alternative commands and start up [tutorial with AWS support](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/running-a-cluster.md)
 * [Tips and tricks](https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/docs/tips-and-tricks.md) for working with Kubernetes and Alfresco Content Services.
-
-**Note:** You'll need to adapt some steps and commands for the Community release.

--- a/docs/customising-deployment.md
+++ b/docs/customising-deployment.md
@@ -1,0 +1,35 @@
+# Customising your deployment
+
+Alfresco Content Services Community is composed of the following images:
+
+1. alfresco-content-repository |  [tags](https://hub.docker.com/r/alfresco/alfresco-content-repository-community/tags/)
+2. alfresco-share | [tags](https://hub.docker.com/r/alfresco/alfresco-share/tags/)
+3. alfresco-search-services | [tags](https://hub.docker.com/r/alfresco/alfresco-search-services/tags/)
+4. postgres | [tags](https://hub.docker.com/r/library/postgres/tags/)
+
+For Docker Compose usage, edit the image tags in the [docker-compose.yml](https://github.com/Alfresco/acs-community-deployment/blob/master/docker-compose/docker-compose.yml) file.  
+
+For Helm charts usage, edit the image tags in the  [values.yaml](https://github.com/Alfresco/acs-community-deployment/blob/master/helm/alfresco-content-services/values.yaml) file.  
+
+```
+project
+│
+└───docker-compose
+│   │
+│   └──docker-compose.yml
+│
+└───helm
+    │  
+    └───alfresco-content-services-community
+        │
+        └───values.yaml
+```
+
+**Note:**
+* Use the recommended image tags, as not all combinations may work.
+* You can modify the values provided in [values.yaml](https://github.com/Alfresco/acs-community-deployment/blob/master/helm/alfresco-content-services-community/values.yaml) when deploying the Helm chart. For example, you can run:
+```bash
+helm install alfresco-incubator/alfresco-content-services-community --set repository.image.tag="yourTag" --set share.image.tag="yourTag"
+```
+* The system should handle pod recreation without any problem as persistent storage is implemented.
+* You can run ```eval $(minikube docker-env)``` to switch to your Minikube Docker environment on Mac OS X.

--- a/docs/customising-deployment.md
+++ b/docs/customising-deployment.md
@@ -9,7 +9,7 @@ Alfresco Content Services Community is composed of the following images:
 
 For Docker Compose usage, edit the image tags in the [docker-compose.yml](https://github.com/Alfresco/acs-community-deployment/blob/master/docker-compose/docker-compose.yml) file.  
 
-For Helm charts usage, edit the image tags in the  [values.yaml](https://github.com/Alfresco/acs-community-deployment/blob/master/helm/alfresco-content-services/values.yaml) file.  
+For Helm charts usage, edit the image tags in the  [values.yaml](https://github.com/Alfresco/acs-community-deployment/blob/master/helm/alfresco-content-services-community/values.yaml) file.  
 
 ```
 project

--- a/docs/customising-deployment.md
+++ b/docs/customising-deployment.md
@@ -30,6 +30,4 @@ project
 * You can modify the values provided in [values.yaml](https://github.com/Alfresco/acs-community-deployment/blob/master/helm/alfresco-content-services-community/values.yaml) when deploying the Helm chart. For example, you can run:
 ```bash
 helm install alfresco-incubator/alfresco-content-services-community --set repository.image.tag="yourTag" --set share.image.tag="yourTag"
-```
-* The system should handle pod recreation without any problem as persistent storage is implemented.
-* You can run ```eval $(minikube docker-env)``` to switch to your Minikube Docker environment on Mac OS X.
+``` 


### PR DESCRIPTION
* Changed the format of the README to match what's in the enterprise project
* Added links to acs-deployment steps with suitable notes (to save duplicating content)
* Split out customizing page into a new doc (as it differs slightly from enterprise)
