### PR TITLE
REPO-3596: Shut down internal APIs

### DIFF
--- a/helm/alfresco-content-services-community/README.md
+++ b/helm/alfresco-content-services-community/README.md
@@ -68,3 +68,6 @@ Parameter | Description | Default
 `postgresql.postgresPassword` | postgresql database password | `alfresco`
 `postgresql.postgresDatabase` | postgresql database name | `alfresco`
 `alfresco-search.resources.requests.memory` | alfresco search service requests memory | `250Mi`
+`alfresco-search.ingress.enabled` | Enable external access for alfresco search service | `false`
+`alfresco-search.ingress.basicAuth` | If `alfresco-search.ingress.enabled` is `true`, user need to provide a `base64` encoded `htpasswd` format user name & password (ex: `echo -n "$(htpasswd -nbm solradmin somepassword)` where `solradmin` is username and `somepassword` is the password) | None
+`alfresco-search.ingress.whitelist_ips` | If `alfresco-search.ingress.enabled` is `true`, user can restrict `/solr` to a list of IP addresses of CIDR notation | `0.0.0.0/0`

--- a/helm/alfresco-content-services-community/requirements.yaml
+++ b/helm/alfresco-content-services-community/requirements.yaml
@@ -10,8 +10,8 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled
 - name: alfresco-search
-  version: 0.0.2
-  repository: http://kubernetes-charts.alfresco.com/incubator
+  version: 0.0.3
+  repository: http://kubernetes-charts.alfresco.com/stable
   condition: alfresco-search.enabled
 - name: alfresco-infrastructure
   version: 1.0.0

--- a/helm/alfresco-content-services-community/templates/NOTES.txt
+++ b/helm/alfresco-content-services-community/templates/NOTES.txt
@@ -5,10 +5,8 @@ You can access all components of Alfresco Content Services Community using the s
 
   Content: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/alfresco
   Share: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/share
-  Solr: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/solr
-
+{{ if index .Values "alfresco-search" "ingress" "enabled" }}  Solr: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/solr {{ end }}
 {{ else }}
-
 If you have a specific DNS address for the cluster please run the following commands to get the application paths and configure ACS:
 
 helm upgrade --reuse-values {{ .Release.Name }} --set externalProtocol="http" --set externalHost="domain.com" --set externalPort="80" alfresco-incubator/alfresco-content-services-community

--- a/helm/alfresco-content-services-community/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services-community/templates/ingress-share.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    # Default limit is 1m, document(s) above this size will throw 413 (Request Entity Too Large) error
+    nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+
 spec:
   rules:
   - http:

--- a/helm/alfresco-content-services-community/values.yaml
+++ b/helm/alfresco-content-services-community/values.yaml
@@ -115,6 +115,10 @@ alfresco-search:
     # The value for "host" is the name of this chart 
     host: alfresco-content-services-community
     port: *repositoryExternalPort
+  ingress:
+    # Alfresco Search services endpoint ('/solr') is disabled by default
+    # To enable it please see: acs-deployment configuration table](https://github.com/Alfresco/acs-deployment/tree/master/helm/alfresco-content-services#configuration)
+    enabled: false
 
 # choose if you want network policy enabled
 networkpolicysetting:


### PR DESCRIPTION
- Alfresco search services endpoint (`/solr`) should be disabled by default
- Documentation updated on how to enable it
- Re-written proxy-body-size to be only applied on `/share` Ingress (previously it was global).