### PR TITLE
ALF-22041: Align helper short name with host passed to ASS

### DIFF
--- a/helm/alfresco-content-services-community/values.yaml
+++ b/helm/alfresco-content-services-community/values.yaml
@@ -118,8 +118,8 @@ alfresco-infrastructure:
 alfresco-search:
   enabled: true
   repository:
-    # The value for "host" is the name of this chart 
-    host: alfresco-content-services-community
+    # The value for "host" is the name of this chart (will be suffixed with -repository by alfresco-search)
+    host: alfresco-cs-ce
     port: *repositoryExternalPort
   ingress:
     # Alfresco Search services endpoint ('/solr') is disabled by default


### PR DESCRIPTION
This ports the same change already applied in the Enterprise chart via https://github.com/Alfresco/acs-deployment/pull/24 to the Community chart. Since "host" may potentially be confusing in this instance (it is not actually the host but the chart name) I also expanded a bit on the comment.

Fixes #31