### PR TITLE
REPO-3682: Renditions: Deployment includes queue by default

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -24,6 +24,7 @@ services:
                 -Dsolr.base.url=/solr
                 -Dindex.subsystem.name=solr6
                 -Dshare.host=localhost
+                -Dmessaging.broker.url=\"failover:(nio://activemq:61616)?timeout=3000&jms.useCompression=true\"
                 -Ddeployment.method=DOCKER_COMPOSE
                 -Dcsrf.filter.enabled=false
                 -Xms1g -Xmx1g

--- a/helm/alfresco-content-services-community/requirements.yaml
+++ b/helm/alfresco-content-services-community/requirements.yaml
@@ -14,6 +14,6 @@ dependencies:
   repository: https://kubernetes-charts.alfresco.com/stable
   condition: alfresco-search.enabled
 - name: alfresco-infrastructure
-  version: 1.0.0
+  version: 2.0.0
   condition: alfresco-content-services.alfresco-infrastructure.enabled
   repository: https://kubernetes-charts.alfresco.com/stable

--- a/helm/alfresco-content-services-community/templates/Rule_04-network-policy-repository.yaml
+++ b/helm/alfresco-content-services-community/templates/Rule_04-network-policy-repository.yaml
@@ -66,6 +66,11 @@ spec:
       - podSelector:
           matchLabels:
              app: {{ template "content-services.shortname" . }}-share
+      
+      # Activemq
+      - podSelector:
+          matchLabels:
+            app: {{ printf "%s-%s" .Release.Name "activemq" }}
 
       # nginx-ingress
       - podSelector:
@@ -89,4 +94,6 @@ spec:
       ports:
       - protocol: TCP
         port: 2049
+      - protocol: TCP
+        port: 61616
 {{- end }}

--- a/helm/alfresco-content-services-community/templates/Rule_10-network-policy-activemq.yaml
+++ b/helm/alfresco-content-services-community/templates/Rule_10-network-policy-activemq.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.networkpolicysetting.enabled }}
+# Allow activemq communication with other components
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: activemq
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ printf "%s-%s" .Release.Name "activemq" }}
+  policyTypes:
+  - Ingress
+  ingress:
+    - from:
+      # Repository
+      - podSelector:
+          matchLabels:
+            app: {{ template "content-services.shortname" . }}-repository
+{{- end }}

--- a/helm/alfresco-content-services-community/templates/config-repository.yaml
+++ b/helm/alfresco-content-services-community/templates/config-repository.yaml
@@ -31,10 +31,7 @@ data:
       -Dcsrf.filter.referer={{ $alfprotocol }}://{{ $alfhost }}/.*
       -Dsolr.host={{ template "alfresco-search.host" . }}
       -Dsolr.port={{ template "alfresco-search.port" . }}
-      -Dalfresco-pdf-renderer.url=http://{{ template "content-services.shortname" . }}-pdfrenderer
-      -Dimg.url=http://{{ template "content-services.shortname" . }}-imagemagick
-      -Djodconverter.url=http://{{ template "content-services.shortname" . }}-libreoffice
-      -Dtika.url=http://{{ template "content-services.shortname" . }}-tika"
+      -Dmessaging.broker.url=failover:(nio://{{ .Release.Name }}-activemq-broker:61616)?timeout=3000&jms.useCompression=true"
   CATALINA_OPTS: " $ALFRESCO_OPTS 
       -Ddb.driver={{ .Values.database.driver | default "org.postgresql.Driver" }}
       {{- if eq .Values.database.external false }}

--- a/helm/alfresco-content-services-community/values.yaml
+++ b/helm/alfresco-content-services-community/values.yaml
@@ -104,15 +104,9 @@ alfresco-content-services:
 # All the components from the alfresco-infrastructure are disabled, because Alfresco Content Services product helm chart
 # only needs the pvc defined in the dependency alfresco-infrastructure
 alfresco-infrastructure:
-  rabbitmq-ha:
-    enabled: false
   activemq:
-    enabled: false
+    enabled: true
   alfresco-identity-service:
-    enabled: false
-  alfresco-activiti-cloud-registry:
-    enabled: false
-  alfresco-api-gateway:
     enabled: false
 
 alfresco-search:


### PR DESCRIPTION
   - updated community to use alfresco-infrastructure 2.0.0 and include queue by default