### PR TITLE
REPO-4130 Fix AOS external URL

### DIFF
--- a/helm/alfresco-content-services-community/templates/config-repository.yaml
+++ b/helm/alfresco-content-services-community/templates/config-repository.yaml
@@ -19,17 +19,23 @@ data:
   RELEASE_NAME: {{ .Release.Name }}
   {{ $alfhost := (.Values.externalHost | default (printf "%s-repository" (include "content-services.shortname" .))) }}
   {{ $alfprotocol := (.Values.externalProtocol | default "http") }}
-  {{ $alfport := (.Values.externalPort | default .Values.repository.service.externalPort) }}
+  {{ $alfport := (.Values.externalPort | default .Values.repository.service.externalPort) | toString }}
   ALFRESCO_OPTS: " -Dalfresco.host={{ $alfhost }}
       -Dalfresco.protocol={{ $alfprotocol }}
       -Dalfresco.port={{ $alfport }}
-      -Daos.baseUrlOverwrite=${alfresco.protocol}://${alfresco.host}:${alfresco.port}/alfresco/aos
+      {{ if or (eq $alfport "80") (eq $alfport "443") }}
+      -Daos.baseUrlOverwrite={{ $alfprotocol }}://{{ $alfhost }}/alfresco/aos
+      -Dcsrf.filter.origin={{ $alfprotocol }}://{{ $alfhost }}
+      -Dcsrf.filter.referer={{ $alfprotocol }}://{{ $alfhost }}/.*
+      {{ else }}
+      -Daos.baseUrlOverwrite={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}/alfresco/aos
+      -Dcsrf.filter.origin={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}
+      -Dcsrf.filter.referer={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}/.*
+      {{ end }}
       -Dshare.protocol={{ .Values.externalProtocol | default "http"}}
       -Dshare.host={{ .Values.externalHost | default (printf "%s-share" (include "content-services.shortname" .)) }}
       -Dshare.port={{ .Values.externalPort | default .Values.share.service.externalPort }}
       -Dalfresco_user_store.adminpassword={{ .Values.repository.adminPassword | default "209c6174da490caeb422f3fa5a7ae634" }}
-      -Dcsrf.filter.origin={{ $alfprotocol }}://{{ $alfhost }}
-      -Dcsrf.filter.referer={{ $alfprotocol }}://{{ $alfhost }}/.*
       -Dsolr.host={{ template "alfresco-search.host" . }}
       -Dsolr.port={{ template "alfresco-search.port" . }}
       -Dmessaging.broker.url=failover:(nio://{{ .Release.Name }}-activemq-broker:61616)?timeout=3000&jms.useCompression=true"


### PR DESCRIPTION
If the external URL has standard ports like 80 or 443,
the property aos.baseUrlOverwrite should not contain them as the
resulting path will not match the client requests.
Non-standard port should be part of URL.