### PR TITLE
Wait for middleware containers to wake up

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -33,6 +33,12 @@ services:
                 "
         ports:
             - 8082:8080 #Browser port
+        depends_on:
+            - share
+            - postgres
+            - solr6
+            - activemq
+        restart: always
 
     share:
         image: alfresco/alfresco-share:6.1.0-RC3

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -34,9 +34,7 @@ services:
         ports:
             - 8082:8080 #Browser port
         depends_on:
-            - share
             - postgres
-            - solr6
             - activemq
         restart: always
 
@@ -49,6 +47,8 @@ services:
             - "CATALINA_OPTS= -Xms500m -Xmx500m"
         ports:
             - 8080:8080
+        depends_on:
+            - alfresco
 
     postgres:
         image: postgres:10.1
@@ -76,6 +76,8 @@ services:
             - "SOLR_JAVA_MEM=-Xms2g -Xmx2g"
         ports:
             - 8083:8983 #Browser port
+        depends_on:
+            - alfresco
 
     activemq:
         image: alfresco/alfresco-activemq:5.15.6

--- a/docker-compose/wait-connection.sh
+++ b/docker-compose/wait-connection.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+TARGET_SERVICE=${1}
+START_COMMAND=${@:2}
+
+echo "TARGET_SERVICE: ${TARGET_SERVICE}"
+echo "START_COMMAND: ${START_COMMAND}"
+
+until `curl -sL http://${TARGET_SERVICE} >/dev/null`; do
+    echo "Waiting for ${TARGET_SERVICE} waking up..."
+    sleep 0.5
+done
+echo "Detected ${TARGET_SERVICE} wake up!"
+
+${START_COMMAND}


### PR DESCRIPTION
# Problem

Sometimes `alfresco` container exits because of connection problems to the middleware containers.

# Solution

Let the `alfresco` container wait for others until they get waken up.