### PR TITLE
Enable customization using extra configmaps configmaps

### DIFF
--- a/helm/alfresco-content-services-community/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-repository.yaml
@@ -41,6 +41,11 @@ spec:
           - name: data
             mountPath: {{ .Values.persistence.repository.data.mountPath }}
             subPath: {{ .Values.persistence.repository.data.subPath }}
+          {{- range .Values.repository.extraConfigmapMounts }}
+          - name: {{ .name }}
+            mountPath: {{ .mountPath }}
+            readOnly: {{ .readOnly }}
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /alfresco/api/-default-/public/alfresco/versions/1/probes/-ready-
@@ -68,3 +73,8 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim }}
+      {{- range .Values.repository.extraConfigmapMounts }}
+      - name: {{ .name }}
+        configMap:
+          name: {{ .configMap }}
+      {{- end }}

--- a/helm/alfresco-content-services-community/values.yaml
+++ b/helm/alfresco-content-services-community/values.yaml
@@ -29,6 +29,17 @@ repository:
       -Dindex.subsystem.name=solr6
       -Ddeployment.method=HELM_CHART
       -Xms2000M -Xmx2000M"
+  extraConfigmapMounts: []
+  # Override example:
+  #
+  # - name: platform-classes-configmap
+  #   mountPath: /usr/local/tomcat/shared/classes
+  #   configMap: platform-classes-configmap
+  #   readOnly: true
+  # - name: extension-classes-configmap
+  #   mountPath: /usr/local/tomcat/shared/classes/alfresco/extension
+  #   configMap: extension-classes-configmap
+  #   readOnly: true
   resources:
     requests:
       memory: "3000Mi"


### PR DESCRIPTION
One might want to use a custom `alfresco-global.properties` or other custom configuration (e.g. logging from `alfresco/extension/*-log4j.properties`.