### PR TITLE
Allow overriding of ingress annotations

### DIFF
--- a/helm/alfresco-content-services-community/templates/ingress-repository.yaml
+++ b/helm/alfresco-content-services-community/templates/ingress-repository.yaml
@@ -3,18 +3,13 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "content-services.shortname" . }}-repository
+  labels:
+    app: {{ template "content-services.shortname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "alf_affinity_route"
-    nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
-    # Default file limit (1m) check, document(s) above this size will throw 413 (Request Entity Too Large) error
-    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.repository.ingress.maxUploadSize }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      location ~ ^(/.*/service/api/solr/.*)$ {return 403;}
-      location ~ ^(/.*/s/api/solr/.*)$ {return 403;}
-      location ~ ^(/.*/wcservice/api/solr/.*)$ {return 403;}
-      location ~ ^(/.*/wcs/api/solr/.*)$ {return 403;}
+{{ toYaml .Values.repository.ingress.annotations | indent 4 }}
 
 spec:
   rules:

--- a/helm/alfresco-content-services-community/templates/ingress-share.yaml
+++ b/helm/alfresco-content-services-community/templates/ingress-share.yaml
@@ -3,13 +3,13 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "content-services.shortname" . }}-share
+  labels:
+    app: {{ template "content-services.shortname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    # Default limit is 1m, document(s) above this size will throw 413 (Request Entity Too Large) error
-    nginx.ingress.kubernetes.io/proxy-body-size: {{ .Values.repository.ingress.maxUploadSize }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      location ~ ^(/.*/proxy/alfresco/api/solr/.*)$ {return 403 ;}
-                  location ~ ^(/.*/-default-/proxy/alfresco/api/.*)$ {return 403;}
+{{ toYaml .Values.repository.ingress.annotations | indent 4 }}
 
 spec:
   rules:

--- a/helm/alfresco-content-services-community/values.yaml
+++ b/helm/alfresco-content-services-community/values.yaml
@@ -21,8 +21,20 @@ repository:
     type: ClusterIP
     externalPort: &repositoryExternalPort 80
   ingress:
+    maxUploadSize: &maxUploadSize "5g"
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/affinity: "cookie"
+      nginx.ingress.kubernetes.io/session-cookie-name: "alf_affinity_route"
+      nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+      # Default file limit (1m) check, document(s) above this size will throw 413 (Request Entity Too Large) error
+      nginx.ingress.kubernetes.io/proxy-body-size: *maxUploadSize
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        location ~ ^(/.*/service/api/solr/.*)$ {return 403;}
+        location ~ ^(/.*/s/api/solr/.*)$ {return 403;}
+        location ~ ^(/.*/wcservice/api/solr/.*)$ {return 403;}
+        location ~ ^(/.*/wcs/api/solr/.*)$ {return 403;}
     path: /alfresco
-    maxUploadSize: "5g"
   environment:
     JAVA_OPTS: " -Dsolr.base.url=/solr
       -Dsolr.secureComms=none
@@ -65,6 +77,13 @@ share:
     type: ClusterIP
     externalPort: 80
   ingress:
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
+      # Default limit is 1m, document(s) above this size will throw 413 (Request Entity Too Large) error
+      nginx.ingress.kubernetes.io/proxy-body-size: *maxUploadSize
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        location ~ ^(/.*/proxy/alfresco/api/solr/.*)$ {return 403 ;}
+        location ~ ^(/.*/-default-/proxy/alfresco/api/.*)$ {return 403;}
     path: /share
   resources:
     requests:


### PR DESCRIPTION
The current chart does not provide an easy way to use an ingress controller other than `ingress-nginx`. `alfresco-search-deployment` has a similar issue. PR coming over there as well.