### PR TITLE
fix: use correct host, name, port value for repository and share configs

### DIFF
--- a/helm/alfresco-content-services-community/templates/NOTES.txt
+++ b/helm/alfresco-content-services-community/templates/NOTES.txt
@@ -1,12 +1,14 @@
 
 {{ if .Values.externalHost }}
-
+{{ $alfhost := tpl .Values.externalHost $ }}
+{{ $alfprotocol := tpl (.Values.externalProtocol | default "http") $ }}
+{{ $alfport := tpl (.Values.externalPort | default .Values.repository.service.externalPort | toString ) $ }}
 You can access all components of Alfresco Content Services Community using the same root address, but different paths as follows:
 
-  Content: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/alfresco
-  Share: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/share
-  Api-Explorer: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/api-explorer
-{{ if index .Values "alfresco-search" "ingress" "enabled" }}  Solr: {{ .Values.externalProtocol | default "http" }}://{{ .Values.externalHost }}:{{ .Values.externalPort | default .Values.repository.service.externalPort }}/solr {{ end }}
+  Content: {{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}/alfresco
+  Share: {{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}/share
+  Api-Explorer: {{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}/api-explorer
+{{ if index .Values "alfresco-search" "ingress" "enabled" }}  Solr: {{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}/solr {{ end }}
 {{ else }}
 If you have a specific DNS address for the cluster please run the following commands to get the application paths and configure ACS:
 

--- a/helm/alfresco-content-services-community/templates/config-repository.yaml
+++ b/helm/alfresco-content-services-community/templates/config-repository.yaml
@@ -32,9 +32,9 @@ data:
       -Dcsrf.filter.origin={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}
       -Dcsrf.filter.referer={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}/.*
       {{ end }}
-      -Dshare.protocol={{ $alfprotocol | default "http"}}
-      -Dshare.host={{ $alfhost | default (printf "%s-share" (include "content-services.shortname" .)) }}
-      -Dshare.port={{ $alfport | default .Values.share.service.externalPort }}
+      -Dshare.protocol={{ tpl (.Values.externalProtocol | default "http") . }}
+      -Dshare.host={{ tpl (.Values.externalHost | default (printf "%s-share" (include "content-services.shortname" .))) . }}
+      -Dshare.port={{ tpl (.Values.externalPort | default .Values.share.service.externalPort | toString ) . }}
       -Dalfresco_user_store.adminpassword={{ .Values.repository.adminPassword | default "209c6174da490caeb422f3fa5a7ae634" }}
       -Dsolr.host={{ template "alfresco-search.host" . }}
       -Dsolr.port={{ template "alfresco-search.port" . }}

--- a/helm/alfresco-content-services-community/templates/config-repository.yaml
+++ b/helm/alfresco-content-services-community/templates/config-repository.yaml
@@ -32,9 +32,9 @@ data:
       -Dcsrf.filter.origin={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}
       -Dcsrf.filter.referer={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}/.*
       {{ end }}
-      -Dshare.protocol={{ .Values.externalProtocol | default "http"}}
-      -Dshare.host={{ .Values.externalHost | default (printf "%s-share" (include "content-services.shortname" .)) }}
-      -Dshare.port={{ .Values.externalPort | default .Values.share.service.externalPort }}
+      -Dshare.protocol={{ $alfprotocol | default "http"}}
+      -Dshare.host={{ $alfhost | default (printf "%s-share" (include "content-services.shortname" .)) }}
+      -Dshare.port={{ $alfport | default .Values.share.service.externalPort }}
       -Dalfresco_user_store.adminpassword={{ .Values.repository.adminPassword | default "209c6174da490caeb422f3fa5a7ae634" }}
       -Dsolr.host={{ template "alfresco-search.host" . }}
       -Dsolr.port={{ template "alfresco-search.port" . }}

--- a/helm/alfresco-content-services-community/templates/config-share.yaml
+++ b/helm/alfresco-content-services-community/templates/config-share.yaml
@@ -11,6 +11,7 @@ metadata:
 data:
   {{ $alfhost := tpl (.Values.externalHost | default (printf "%s-share" (include "content-services.shortname" .))) $ }}
   {{ $alfprotocol := tpl (.Values.externalProtocol | default "http") $ }}
+  {{ $alfport := tpl (.Values.externalPort | default "80" | toString ) $ }}
   # The CATALINA_OPTS defined in the values.yaml file for the "share" are set here using proper quotes
   {{- if .Values.share.environment }}
   {{- range $key, $val := .Values.share.environment }}
@@ -21,3 +22,4 @@ data:
   REPO_PORT: "{{ .Values.repository.service.externalPort }}"
   CSRF_FILTER_REFERER: "{{ $alfprotocol }}://{{ $alfhost }}/.*"
   CSRF_FILTER_ORIGIN: "{{ $alfprotocol }}://{{ $alfhost }}"
+  JAVA_OPTS: "-Dalfresco.proxy={{ $alfprotocol }}://{{ $alfhost }}:{{ $alfport }}"


### PR DESCRIPTION
This PR fixes a problem with creating repository and share configurations using templated values for externalHost, externalPort and externalProtocol, This fix is required for deploying ACS together with AAE 7.1 Helm chart