### PR TITLE
REPO-4569: Use registryPullSecrets as a global value for parent and child Alfresco Helm charts

### DIFF
--- a/docs/helm-deployment-aws_kops.md
+++ b/docs/helm-deployment-aws_kops.md
@@ -357,7 +357,7 @@ kubectl create -f secrets.yaml --namespace $DESIREDNAMESPACE
 secret "quay-registry-secret" created
 ```
 
-**Note:** When installing the ACS Helm chart and using private Docker images from Quay.io, make sure you add the variable ```--set registryPullSecrets=quay-registry-secret``` in the `helm install` command.
+**Note:** When installing the ACS Helm chart and using private Docker images from Quay.io, make sure you add the variable ```--set global.alfrescoRegistryPullSecrets=quay-registry-secret``` in the `helm install` command.
 
 
 ### Deploying Alfresco Content Services Community

--- a/helm/alfresco-content-services-community/Chart.yaml
+++ b/helm/alfresco-content-services-community/Chart.yaml
@@ -1,5 +1,5 @@
 name: alfresco-content-services-community
-version: 3.1.0
+version: 3.1.1
 appVersion: 6.2.0-A11
 description: A Helm chart for deploying Alfresco Content Services Community
 keywords:

--- a/helm/alfresco-content-services-community/requirements.yaml
+++ b/helm/alfresco-content-services-community/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled
 - name: alfresco-search
-  version: 1.0.0
+  version: 1.1.1
   repository: https://kubernetes-charts.alfresco.com/stable
   condition: alfresco-search.enabled
 - name: alfresco-infrastructure

--- a/helm/alfresco-content-services-community/requirements.yaml
+++ b/helm/alfresco-content-services-community/requirements.yaml
@@ -10,7 +10,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled
 - name: alfresco-search
-  version: 1.1.1
+  version: 1.0.1
   repository: https://kubernetes-charts.alfresco.com/stable
   condition: alfresco-search.enabled
 - name: alfresco-infrastructure

--- a/helm/alfresco-content-services-community/templates/deployment-imagemagick.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-imagemagick.yaml
@@ -19,10 +19,10 @@ spec:
         release: {{ .Release.Name }}
         component: transformers
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/helm/alfresco-content-services-community/templates/deployment-libreoffice.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-libreoffice.yaml
@@ -19,10 +19,10 @@ spec:
         release: {{ .Release.Name }}
         component: transformers
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/helm/alfresco-content-services-community/templates/deployment-pdfrenderer.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-pdfrenderer.yaml
@@ -19,10 +19,10 @@ spec:
         release: {{ .Release.Name }}
         component: transformers
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/helm/alfresco-content-services-community/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-repository.yaml
@@ -18,10 +18,10 @@ spec:
         release: {{ .Release.Name }}
         component: repository
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/alfresco-content-services-community/templates/deployment-share.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-share.yaml
@@ -18,10 +18,10 @@ spec:
         release: {{ .Release.Name }}
         component: share
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/alfresco-content-services-community/templates/deployment-tika.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-tika.yaml
@@ -19,10 +19,10 @@ spec:
         release: {{ .Release.Name }}
         component: transformers
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/helm/alfresco-content-services-community/templates/deployment-transform-misc.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-transform-misc.yaml
@@ -19,10 +19,10 @@ spec:
         release: {{ .Release.Name }}
         component: transformers
     spec:
-      {{- if .Values.registryPullSecrets }}
+      {{- if .Values.global.alfrescoRegistryPullSecrets }}
       # only set this secret if a private docker registry variable is defined
       imagePullSecrets:
-        - name: {{ .Values.registryPullSecrets }}
+        - name: {{ .Values.global.alfrescoRegistryPullSecrets }}
       {{- end }}
       affinity:
         podAntiAffinity:

--- a/helm/alfresco-content-services-community/values.yaml
+++ b/helm/alfresco-content-services-community/values.yaml
@@ -330,7 +330,11 @@ postgresql:
 
 # If there is a need to pull images from a private docker repo, a secret can be defined in helm and passed as an argument
 # to the install command:
-# e.g.: helm install alfresco-content-services --set registryPullSecrets=private-repo-registry-secret
+# e.g.: helm install alfresco-content-services --set global.alfrescoRegistryPullSecrets=private-repo-registry-secret
 # or uncomment the following line if you don't want/need to pass it as a parameter on every install command :
 # registryPullSecrets: private-repo-registry-secret
 # for more information: https://github.com/Alfresco/alfresco-anaxes-shipyard/blob/master/SECRETS.md
+
+# Global definition of Docker registry pull secret which can be accessed by dependent ACS Helm chart(s)
+global:
+  alfrescoRegistryPullSecrets:


### PR DESCRIPTION
- Defined a new global variable called alfrescoRegistryPullSecrets in ACS parent and child helm chart and updated chart versions
- These changes are made for ACS Helm chart version 6.2 for master branch