### PR TITLE
Kubernetes 1.16 Compatibility

### DIFF
--- a/helm/alfresco-content-services-community/requirements.yaml
+++ b/helm/alfresco-content-services-community/requirements.yaml
@@ -6,7 +6,7 @@
 #       is really required from the alfresco-infrastructure to start up the Alfresco Content Services product
 dependencies:
 - name: postgresql
-  version: 0.9.3
+  version: 7.7.3
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: postgresql.enabled
 - name: alfresco-search

--- a/helm/alfresco-content-services-community/templates/deployment-imagemagick.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-imagemagick.yaml
@@ -1,6 +1,6 @@
 # Defines the deployment for the imagemagick transformer app
 # Details: https://git.alfresco.com/Repository/alfresco-docker-transformers
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "content-services.shortname" . }}-imagemagick
@@ -12,6 +12,9 @@ metadata:
     component: transformers
 spec:
   replicas: {{ .Values.imagemagick.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "content-services.shortname" . }}-imagemagick
   template:
     metadata:
       labels:

--- a/helm/alfresco-content-services-community/templates/deployment-imagemagick.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-imagemagick.yaml
@@ -59,6 +59,7 @@ spec:
           ports:
             - containerPort: {{ .Values.imagemagick.image.internalPort }}
           resources:
+{{ toYaml .Values.imagemagick.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /ready
@@ -74,4 +75,3 @@ spec:
             periodSeconds: {{ .Values.imagemagick.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.imagemagick.livenessProbe.timeoutSeconds }}
-{{ toYaml .Values.imagemagick.resources | indent 12 }}

--- a/helm/alfresco-content-services-community/templates/deployment-libreoffice.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-libreoffice.yaml
@@ -1,6 +1,6 @@
 # Defines the deployment for the libreoffice transformer app
 # Details: https://git.alfresco.com/Repository/alfresco-docker-transformers
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "content-services.shortname" . }}-libreoffice
@@ -12,6 +12,9 @@ metadata:
     component: transformers
 spec:
   replicas: {{ .Values.libreoffice.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "content-services.shortname" . }}-libreoffice
   template:
     metadata:
       labels:

--- a/helm/alfresco-content-services-community/templates/deployment-libreoffice.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-libreoffice.yaml
@@ -59,6 +59,7 @@ spec:
           ports:
             - containerPort: {{ .Values.libreoffice.image.internalPort }}
           resources:
+{{ toYaml .Values.libreoffice.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /ready
@@ -74,4 +75,3 @@ spec:
             periodSeconds: {{ .Values.libreoffice.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.libreoffice.livenessProbe.timeoutSeconds }}
-{{ toYaml .Values.libreoffice.resources | indent 12 }}

--- a/helm/alfresco-content-services-community/templates/deployment-pdfrenderer.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-pdfrenderer.yaml
@@ -1,6 +1,6 @@
 # Defines the deployment for the pdfrenderer transformer app
 # Details: https://git.alfresco.com/Repository/alfresco-docker-transformers
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "content-services.shortname" . }}-pdfrenderer
@@ -12,6 +12,9 @@ metadata:
     component: transformers
 spec:
   replicas: {{ .Values.pdfrenderer.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "content-services.shortname" . }}-pdfrenderer
   template:
     metadata:
       labels:

--- a/helm/alfresco-content-services-community/templates/deployment-pdfrenderer.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-pdfrenderer.yaml
@@ -59,6 +59,7 @@ spec:
           ports:
             - containerPort: {{ .Values.pdfrenderer.image.internalPort }}
           resources:
+{{ toYaml .Values.pdfrenderer.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /ready
@@ -74,4 +75,3 @@ spec:
             periodSeconds: {{ .Values.pdfrenderer.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.pdfrenderer.livenessProbe.timeoutSeconds }}
-{{ toYaml .Values.pdfrenderer.resources | indent 12 }}

--- a/helm/alfresco-content-services-community/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-repository.yaml
@@ -1,5 +1,5 @@
 # Defines the deployment for the alfresco content repository app
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "content-services.shortname" . }}-repository
@@ -11,6 +11,9 @@ metadata:
     component: repository
 spec:
   replicas: {{ .Values.repository.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "content-services.shortname" . }}-repository
   template:
     metadata:
       labels:
@@ -28,7 +31,7 @@ spec:
           image: "{{ .Values.repository.image.repository }}:{{ .Values.repository.image.tag }}"
           imagePullPolicy: {{ .Values.repository.image.pullPolicy }}
           envFrom:
-          - secretRef: 
+          - secretRef:
               name: {{ template "content-services.shortname" . }}-dbsecret
           - configMapRef:
               # config map to use, defined in config-repository.yaml

--- a/helm/alfresco-content-services-community/templates/deployment-share.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-share.yaml
@@ -1,5 +1,5 @@
 # Defines the deployment for the alfresco share app
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "content-services.shortname" . }}-share
@@ -11,6 +11,9 @@ metadata:
     component: share
 spec:
   replicas: {{ .Values.share.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "content-services.shortname" . }}-share
   template:
     metadata:
       labels:

--- a/helm/alfresco-content-services-community/templates/deployment-tika.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-tika.yaml
@@ -1,6 +1,6 @@
 # Defines the deployment for the tika transformer app
 # Details: https://git.alfresco.com/Repository/alfresco-docker-transformers
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "content-services.shortname" . }}-tika
@@ -12,6 +12,9 @@ metadata:
     component: transformers
 spec:
   replicas: {{ .Values.tika.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "content-services.shortname" . }}-tika
   template:
     metadata:
       labels:

--- a/helm/alfresco-content-services-community/templates/deployment-tika.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-tika.yaml
@@ -59,6 +59,7 @@ spec:
           ports:
             - containerPort: {{ .Values.tika.image.internalPort }}
           resources:
+{{ toYaml .Values.tika.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /ready
@@ -74,4 +75,3 @@ spec:
             periodSeconds: {{ .Values.tika.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.tika.livenessProbe.timeoutSeconds }}
-{{ toYaml .Values.tika.resources | indent 12 }}

--- a/helm/alfresco-content-services-community/templates/deployment-transform-misc.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-transform-misc.yaml
@@ -59,6 +59,7 @@ spec:
           ports:
             - containerPort: {{ .Values.transformmisc.image.internalPort }}
           resources:
+{{ toYaml .Values.transformmisc.resources | indent 12 }}
           readinessProbe:
             httpGet:
               path: /ready
@@ -74,4 +75,3 @@ spec:
             periodSeconds: {{ .Values.transformmisc.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.transformmisc.livenessProbe.timeoutSeconds }}
-{{ toYaml .Values.transformmisc.resources | indent 12 }}

--- a/helm/alfresco-content-services-community/templates/deployment-transform-misc.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-transform-misc.yaml
@@ -1,6 +1,6 @@
 # Defines the deployment for the transform-misc transformer app
 # Details: https://git.alfresco.com/Repository/alfresco-docker-transformers
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "content-services.shortname" . }}-transform-misc
@@ -12,6 +12,9 @@ metadata:
     component: transformers
 spec:
   replicas: {{ .Values.transformmisc.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "content-services.shortname" . }}-transform-misc
   template:
     metadata:
       labels:


### PR DESCRIPTION
- Kubernetes 1.16 removed deprecated api version `extensions/v1beta1`. This has to be replaced by `apps/v1`.
- The new api version specifies the `selector` field as required for a `Deployment` and is therefore being added.
- The `postgresql` chart version has to be compatible with Kubernetes Version 1.16 and is updated to version 7.7.3.

Fixes #93 