### PR TITLE
Update deployment-repository.yaml

### DIFF
--- a/helm/alfresco-content-services-community/templates/deployment-repository.yaml
+++ b/helm/alfresco-content-services-community/templates/deployment-repository.yaml
@@ -57,8 +57,8 @@ spec:
             periodSeconds: {{ .Values.repository.livenessProbe.periodSeconds }}
             failureThreshold: 1
             timeoutSeconds: {{ .Values.repository.livenessProbe.timeoutSeconds }}
-      {{- if eq .Values.database.external false }}
       initContainers:
+      {{- if eq .Values.database.external false }}
         # wait for the DB to startup before this deployment can start
         - name: init-db
           image: busybox


### PR DESCRIPTION
if the database is external init-fs is continuously failing as a container because it does not have the initContainer label, would it be possible to make this change o similar?